### PR TITLE
fix: 메인 함수에서 무한 루프를 돌면서 cpu를 잡아먹는 버그 수정

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,15 +38,14 @@ func render() {
 	tui.Render(grid)
 }
 
-func handleSignal(e tui.Event) bool {
+func handleSignal(e tui.Event) {
 	if e.ID == "q" || e.ID == "<C-c>" {
 		endChan <- struct{}{}
-		return true
+		return
 	}
 
 	memoryWidget.HandleSignal(e)
 	processWidget.HandleSignal(e)
-	return false
 }
 
 func updateWidgets() {
@@ -60,9 +59,7 @@ func handleEvents() {
 		uiEvents := tui.PollEvents()
 		for {
 			e := <-uiEvents
-			if handleSignal(e) {
-				return
-			}
+			handleSignal(e)
 			render()
 		}
 	}()


### PR DESCRIPTION
## 무엇이 변경되었나요? 🎉

시간마다 혹은 키보드 입력이 들어왔을 때, 무한 루프를 돌면서 채널에 값이 있는지를 체크하고 있어서 cpu를 잡아먹고 있었음.

- 각 함수들을 goroutine에서 실행하게 하고 채널에 값이 있는지를 체크하는게 아니고 값이 없으면 계산을 멈추게 함.
```go
# AS-IS
for {
    select {
    case e := <-events
        ....
    }
}

# TO-BE
go func() {
    for {
        e := <-events
        ....
    }
}()
```
- 다른 goroutine에서 요청을 처리하다보니 메인 함수의 종료 처리가 필요해져서 endChan을 만듬
  - handleSignal의 리턴 값이 의미가 없어져 void 타입으로 변경


## 추가로 알아야 할 것을 알려주세요! 🥺 (선택사항)

각각 goroutine로 돌게 되어서 각 위젯에서 키보드입력, 시간마다 refresh 에 해당하는 이벤트가 동시에 발생해서 생길 수 있는 race condition을 고려해줘야 할 수 있습니다. (ex. 프로세스에서 커서 위치?)
혹은 두개의 goroutine를 통합하는 방법도 생각할 수 있을 것 같습니다.
