### PR TITLE
fix: CPU 위젯 리팩토링 및 초기화 이슈 수정

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/gizak/termui v3.1.0+incompatible // indirect
-	github.com/gizak/termui/v3 v3.1.0 // indirect
+	github.com/gizak/termui/v3 v3.1.0
 )

--- a/widgets/cpu.go
+++ b/widgets/cpu.go
@@ -41,11 +41,6 @@ func NewCpuWidget() Widget {
 	cpuStats, err := getCpuStats()
 	if err != nil {
 		log.Fatal(err)
-		cores := runtime.NumCPU()
-		cpuStats = CpuStats{
-			cores: cores,
-			stats: make([]CpuCoreStats, cores),
-		}
 	}
 
 	data := make([][]float64, cpuStats.cores)
@@ -67,7 +62,7 @@ func NewCpuWidget() Widget {
 func (widget *CpuWidget) Update() {
 	currentCpuStats, err := getCpuStats()
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return
 	}
 

--- a/widgets/cpu.go
+++ b/widgets/cpu.go
@@ -41,6 +41,11 @@ func NewCpuWidget() Widget {
 	cpuStats, err := getCpuStats()
 	if err != nil {
 		log.Fatal(err)
+		cores := runtime.NumCPU()
+		cpuStats = CpuStats{
+			cores: cores,
+			stats: make([]CpuCoreStats, cores),
+		}
 	}
 
 	data := make([][]float64, cpuStats.cores)

--- a/widgets/cpu.go
+++ b/widgets/cpu.go
@@ -114,11 +114,17 @@ func getCpuStats() CpuStats {
 func parseCpuCoreStats(cpuCoreStats string) CpuCoreStats {
 	cpuTimes := strings.Fields(cpuCoreStats)[1:]
 
-	userProcessTime, _ := strconv.ParseUint(cpuTimes[0], 10, 64)
+	userProcessTime, err := strconv.ParseUint(cpuTimes[0], 10, 64)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	totalTime := uint64(0)
 	for _, data := range cpuTimes {
-		time, _ := strconv.ParseUint(data, 10, 64)
+		time, err := strconv.ParseUint(data, 10, 64)
+		if err != nil {
+			log.Fatal(err)
+		}
 		totalTime += time
 	}
 

--- a/widgets/cpu.go
+++ b/widgets/cpu.go
@@ -30,6 +30,57 @@ type CpuWidget struct {
 
 var HORIZONTAL_SCALE = 3
 
+func NewCpuWidget() Widget {
+	plot := tWidgets.NewPlot()
+	plot.Title = " CPU Usage "
+	plot.AxesColor = tui.ColorWhite
+	plot.HorizontalScale = HORIZONTAL_SCALE
+	plot.ShowAxes = false
+	plot.MaxVal = 100
+
+	cpuStats := getCpuStats()
+
+	data := make([][]float64, cpuStats.cores)
+
+	termWidth, _ := tui.TerminalDimensions()
+	for i := 0; i < cpuStats.cores; i++ {
+		data[i] = make([]float64, termWidth/HORIZONTAL_SCALE+1)
+	}
+
+	plot.Data = data
+
+	return &CpuWidget{
+		cpuStats: cpuStats,
+		data:     data,
+		plot:     plot,
+	}
+}
+
+func (widget *CpuWidget) Update() {
+	currentCpuStats := getCpuStats()
+	previousCpuStats := widget.cpuStats
+
+	cores := currentCpuStats.cores
+	for core := 0; core < cores; core++ {
+		previousCoreStats := previousCpuStats.stats[core]
+		currentCoreStats := currentCpuStats.stats[core]
+
+		coreUsage := calculateCoreUsage(previousCoreStats, currentCoreStats)
+		widget.pushCoreUsageData(core, coreUsage)
+	}
+
+	widget.cpuStats = currentCpuStats
+}
+
+func (widget *CpuWidget) HandleSignal(event tui.Event) {
+	// is there anything to handle?
+}
+
+func (widget *CpuWidget) GetUI() tui.Drawable {
+	widget.plot.Data = widget.data
+	return widget.plot
+}
+
 // read and parse cpu usage data from /proc/stat
 func getCpuStats() CpuStats {
 	file, err := os.Open("/proc/stat")
@@ -84,58 +135,7 @@ func calculateCoreUsage(previousCoreStats, currentCoreStats CpuCoreStats) float6
 	return (float64(deltaUserProcessTime) / float64(deltaTotalTime)) * 100.0
 }
 
-func (widget *CpuWidget) pushData(core int, coreUsage float64) {
+func (widget *CpuWidget) pushCoreUsageData(core int, coreUsage float64) {
 	widget.data[core] = append(widget.data[core], coreUsage)
 	widget.data[core] = widget.data[core][1:]
-}
-
-func NewCpuWidget() Widget {
-	plot := tWidgets.NewPlot()
-	plot.Title = " CPU Usage "
-	plot.AxesColor = tui.ColorWhite
-	plot.HorizontalScale = HORIZONTAL_SCALE
-	plot.ShowAxes = false
-	plot.MaxVal = 100
-
-	cpuStats := getCpuStats()
-
-	data := make([][]float64, cpuStats.cores)
-
-	termWidth, _ := tui.TerminalDimensions()
-	for i := 0; i < cpuStats.cores; i++ {
-		data[i] = make([]float64, termWidth/HORIZONTAL_SCALE+1)
-	}
-
-	plot.Data = data
-
-	return &CpuWidget{
-		cpuStats: cpuStats,
-		data:     data,
-		plot:     plot,
-	}
-}
-
-func (widget *CpuWidget) Update() {
-	currentCpuStats := getCpuStats()
-	previousCpuStats := widget.cpuStats
-
-	cores := currentCpuStats.cores
-	for core := 0; core < cores; core++ {
-		previousCoreStats := previousCpuStats.stats[core]
-		currentCoreStats := currentCpuStats.stats[core]
-
-		coreUsage := calculateCoreUsage(previousCoreStats, currentCoreStats)
-		widget.pushData(core, coreUsage)
-	}
-
-	widget.cpuStats = currentCpuStats
-}
-
-func (widget *CpuWidget) HandleSignal(event tui.Event) {
-	// is there anything to handle?
-}
-
-func (widget *CpuWidget) GetUI() tui.Drawable {
-	widget.plot.Data = widget.data
-	return widget.plot
 }


### PR DESCRIPTION
## 수정 내역

- 처음에 위젯이 초기화 될 때 모두 값을 0으로 초기화합니다. 이렇게 되면 제일 처음에 계산되는 CPU usage 는 잘못된 값입니다. 따라서 초기화 시 `/proc/stat` 에서 한 번 데이터를 읽어오도록 수정했습니다.
- 기타 리팩토링