### PR TITLE
feat: CPU/Memory 위젯 Resize 기능 추가

### DIFF
--- a/constants/data_length.go
+++ b/constants/data_length.go
@@ -1,4 +1,4 @@
 package constants
 
 // CPU, Memory Widget 에서 들고 있는 최대 데이터 개수
-var MaxDataLength = 2000
+const MaxDataLength = 2000

--- a/constants/data_length.go
+++ b/constants/data_length.go
@@ -1,0 +1,4 @@
+package constants
+
+// CPU, Memory Widget 에서 들고 있는 최대 데이터 개수
+var MaxDataLength = 2000

--- a/util/slice.go
+++ b/util/slice.go
@@ -6,3 +6,14 @@ func PushUsageData(data []float64, value float64) []float64 {
 	data = data[1:]
 	return data
 }
+
+// 2D slice 의 각 row 의 마지막 원소를 원하는 만큼 가져옵니다.
+func GetLastElementsOfEachRow(data [][]float64, length int) [][]float64 {
+	rows := len(data)
+	lastElements := make([][]float64, rows)
+
+	for i, row := range data {
+		lastElements[i] = row[len(row)-length:]
+	}
+	return lastElements
+}

--- a/util/slice.go
+++ b/util/slice.go
@@ -7,7 +7,7 @@ func PushUsageData(data []float64, value float64) []float64 {
 	return data
 }
 
-// 2D slice 의 각 row 의 마지막 원소를 원하는 만큼 가져옵니다.
+// 2D slice 의 각 row 의 마지막 원소를 원하는 개수만큼 가져옵니다.
 func GetLastElementsOfEachRow(data [][]float64, length int) [][]float64 {
 	rows := len(data)
 	lastElements := make([][]float64, rows)
@@ -16,4 +16,9 @@ func GetLastElementsOfEachRow(data [][]float64, length int) [][]float64 {
 		lastElements[i] = row[len(row)-length:]
 	}
 	return lastElements
+}
+
+// slice 의 마지막 원소를 원하는 개수만큼 가져옵니다.
+func GetLastElements(data []float64, length int) []float64 {
+	return data[len(data)-length:]
 }

--- a/widgets/cpu.go
+++ b/widgets/cpu.go
@@ -6,6 +6,7 @@ import (
 	tui "github.com/gizak/termui/v3"
 	tWidgets "github.com/gizak/termui/v3/widgets"
 
+	constants "github.com/sunghun7511/gotop/constants"
 	"github.com/sunghun7511/gotop/core"
 	"github.com/sunghun7511/gotop/model"
 	"github.com/sunghun7511/gotop/util"
@@ -20,7 +21,6 @@ type CpuWidget struct {
 }
 
 var HorizontalScale = 3
-var MaxDataLength = 2000
 
 func NewCpuWidget() Widget {
 	plot := tWidgets.NewPlot()
@@ -38,11 +38,11 @@ func NewCpuWidget() Widget {
 	data := make([][]float64, cpuStats.Cores)
 
 	for i := 0; i < cpuStats.Cores; i++ {
-		data[i] = make([]float64, MaxDataLength)
+		data[i] = make([]float64, constants.MaxDataLength)
 	}
 
 	totalData := make([][]float64, 1)
-	totalData[0] = make([]float64, MaxDataLength)
+	totalData[0] = make([]float64, constants.MaxDataLength)
 
 	return &CpuWidget{
 		cpuStats:     cpuStats,
@@ -84,13 +84,13 @@ func (widget *CpuWidget) HandleSignal(event tui.Event) {
 	}
 }
 
-func calculateDataLength() int {
+func calculateCpuWidgetDataLength() int {
 	termWidth, _ := tui.TerminalDimensions()
 	return termWidth/HorizontalScale + 1
 }
 
 func (widget *CpuWidget) GetUI() tui.Drawable {
-	dataLength := calculateDataLength()
+	dataLength := calculateCpuWidgetDataLength()
 	if widget.showEachCore {
 		widget.plot.Data = util.GetLastElementsOfEachRow(widget.data, dataLength)
 	} else {

--- a/widgets/memory.go
+++ b/widgets/memory.go
@@ -4,6 +4,7 @@ import (
 	tui "github.com/gizak/termui/v3"
 	tWidgets "github.com/gizak/termui/v3/widgets"
 
+	constants "github.com/sunghun7511/gotop/constants"
 	"github.com/sunghun7511/gotop/core"
 	"github.com/sunghun7511/gotop/util"
 )
@@ -22,9 +23,8 @@ func NewMemoryWidget() Widget {
 	group := tWidgets.NewSparklineGroup(widget)
 	group.Title = "Memory Usage"
 
-	termWidth, _ := tui.TerminalDimensions()
 	return &MemoryWidget{
-		history: make([]float64, termWidth/2-2),
+		history: make([]float64, constants.MaxDataLength),
 		widget:  widget,
 		group:   group,
 	}
@@ -45,7 +45,13 @@ func (widget *MemoryWidget) HandleSignal(event tui.Event) {
 	}
 }
 
+func calculateMemoryWidgetDataLength() int {
+	termWidth, _ := tui.TerminalDimensions()
+	return termWidth/2 - 2
+}
+
 func (widget *MemoryWidget) GetUI() tui.Drawable {
-	widget.widget.Data = widget.history
+	dataLength := calculateMemoryWidgetDataLength()
+	widget.widget.Data = util.GetLastElements(widget.history, dataLength)
 	return widget.group
 }


### PR DESCRIPTION
## 수정 내용

resolves #10 

- CPU/Memory 위젯을 수정했습니다.
- 터미널의 크기가 변경될 때, 터미널에 그려지는 데이터의 길이를 유동적으로 조절하여 보여주도록 합니다.
- 내부적으로 저장하는 데이터의 총 길이는 2000개이고, 이 중 마지막 N개만 가져와서 터미널에 보여주도록 합니다.
  - 이렇게 하지 않고 터미널의 크기에 맞춰 데이터의 길이를 조절하게 되면 크기를 줄였다가 늘렸을 때 데이터 앞부분이 손실되게 됩니다.