### PR TITLE
fix: sparkline 오류 해결

### DIFF
--- a/util/fixed_sparkline.go
+++ b/util/fixed_sparkline.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	. "github.com/gizak/termui/v3"
+	. "github.com/gizak/termui/v3/widgets"
+
+	"image"
+	"math"
+)
+
+type FixedSparklineGroup struct {
+	SparklineGroup
+}
+
+func (self *FixedSparklineGroup) Draw(buf *Buffer) {
+	self.Block.Draw(buf)
+
+	sparklineHeight := self.Inner.Dy() / len(self.Sparklines)
+
+	for i, sl := range self.Sparklines {
+		heightOffset := (sparklineHeight * (i + 1))
+		barHeight := sparklineHeight
+		if i == len(self.Sparklines)-1 {
+			heightOffset = self.Inner.Dy()
+			barHeight = self.Inner.Dy() - (sparklineHeight * i)
+		}
+		if sl.Title != "" {
+			barHeight--
+		}
+
+		maxVal := sl.MaxVal
+		if maxVal == 0 {
+			maxVal, _ = GetMaxFloat64FromSlice(sl.Data)
+		}
+
+		// draw line
+		for j := 0; j < len(sl.Data) && j < self.Inner.Dx(); j++ {
+			data := sl.Data[j]
+			height := (data / maxVal) * float64(barHeight)
+			sparkChar := BARS[len(BARS)-1]
+			k := 0
+			for ; k < int(height); k++ {
+				buf.SetCell(
+					NewCell(sparkChar, NewStyle(sl.LineColor)),
+					image.Pt(j+self.Inner.Min.X, self.Inner.Min.Y-1+heightOffset-k),
+				)
+			}
+			if height == 0 {
+				sparkChar = BARS[1]
+				buf.SetCell(
+					NewCell(sparkChar, NewStyle(sl.LineColor)),
+					image.Pt(j+self.Inner.Min.X, self.Inner.Min.Y-1+heightOffset),
+				)
+			} else {
+				kHeight := height - math.Floor(height)
+				sparkChar = BARS[int(kHeight*float64(len(BARS)-1))]
+				buf.SetCell(
+					NewCell(sparkChar, NewStyle(sl.LineColor)),
+					image.Pt(j+self.Inner.Min.X, self.Inner.Min.Y-1+heightOffset-k),
+				)
+			}
+		}
+
+		if sl.Title != "" {
+			// draw title
+			buf.SetString(
+				TrimString(sl.Title, self.Inner.Dx()),
+				sl.TitleStyle,
+				image.Pt(self.Inner.Min.X, self.Inner.Min.Y-1+heightOffset-barHeight),
+			)
+		}
+	}
+}

--- a/widgets/memory.go
+++ b/widgets/memory.go
@@ -11,7 +11,7 @@ import (
 type MemoryWidget struct {
 	history []float64
 	widget  *tWidgets.Sparkline
-	group   *tWidgets.SparklineGroup
+	group   *util.FixedSparklineGroup
 }
 
 func NewMemoryWidget() Widget {
@@ -19,14 +19,14 @@ func NewMemoryWidget() Widget {
 	widget.LineColor = tui.ColorGreen
 	widget.MaxVal = 100
 
-	group := tWidgets.NewSparklineGroup(widget)
+	group := util.FixedSparklineGroup{*tWidgets.NewSparklineGroup(widget)}
 	group.Title = "Memory Usage"
 
 	termWidth, _ := tui.TerminalDimensions()
 	return &MemoryWidget{
 		history: make([]float64, termWidth/2-2),
 		widget:  widget,
-		group:   group,
+		group:   &group,
 	}
 }
 


### PR DESCRIPTION
## 어떤 오류인가요?

[termui](https://github.com/gizak/termui) 라이브러리에서 Sparkline 위젯을 사용할 때 라인 별로 채워지거나 채워지지 않는 형태로 구현됐는데, 이 구현이 미흡한 것 같아 이를 수정했습니다.

### Before
![Before](https://user-images.githubusercontent.com/12845407/128902584-966f9f86-682f-4d0a-b41c-b4d321015eb5.png)

### After
![After](https://user-images.githubusercontent.com/12845407/128902193-9d20cc24-5fe4-40e1-912b-2f03139d8c19.png)
